### PR TITLE
fix multi-threading

### DIFF
--- a/examples/pipfp.rs
+++ b/examples/pipfp.rs
@@ -1,8 +1,8 @@
 use clap::Parser;
 use niffler::send::from_path;
 use pfp::hash::HT;
-use pfp::parse::{parse_seq, parse_seq_par, LT};
-use rayon::{current_num_threads, ThreadPoolBuilder};
+use pfp::parse::{LT, parse_seq, parse_seq_par};
+use rayon::{ThreadPoolBuilder, current_num_threads};
 use seq_io::fasta::{self, Record};
 use std::path::Path;
 use std::time::Instant;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
 pub mod hash;
 pub mod parse;
 
-pub use parse::{parse_seq, parse_seq_par, Parse, ParseIterator};
+pub use parse::{Parse, ParseIterator, parse_seq, parse_seq_par};


### PR DESCRIPTION
Hi @imartayan,

  With this fix we now get the same results between the single and multi-threaded versions.  Looking at the relevant changes, you can see that there were 2 main bug fixes. First, there was a copy-paste error as we had:

```
let (prefix_hash, prefix_len) = borders[i].1;
```

which should have been

```
let (prefix_hash, prefix_len) = borders[i].0;
```

The second is that when we merge the hashes between segment `i` and `i+1`, we actually wish to call `merge_hashes(suffix_hash, prefix_hash, prefix_len as u32 - overlap);` rather than `merge_hashes(suffix_hash, prefix_hash, prefix_len as u32);`.  Honestly, it took me longer than I care to admit to track down these two issues, but it seems to resolve things.  Let me know if you have any thoughts.